### PR TITLE
More robust initialization against a delay of info

### DIFF
--- a/path_planning_ws/src/maze_bot/maze_bot/maze_solver.py
+++ b/path_planning_ws/src/maze_bot/maze_bot/maze_solver.py
@@ -71,17 +71,22 @@ class maze_solver(Node):
         self.vel_subscriber = self.create_subscription(Odometry,'/odom',self.get_bot_speed,10)
         self.bot_speed = 0
         self.bot_turning = 0
-
-        self.sat_view = np.zeros((100,100))
+        self.have_bot_view = False
+        self.bot_view= None
+        self.have_sat_view = False
+        self.sat_view = None
+        #self.sat_view = np.zeros((100,100))
 
         self.debugging = Debugging()
 
     def get_video_feed_cb(self,data):
         frame = self.bridge.imgmsg_to_cv2(data,'bgr8')
         self.sat_view = frame
+        self.have_sat_view = True
     
     def process_data_bot(self, data):
-      self.bot_view = self.bridge.imgmsg_to_cv2(data,'bgr8') # performing conversion
+        self.bot_view = self.bridge.imgmsg_to_cv2(data,'bgr8') # performing conversion
+        self.have_bot_view = True
 
     def get_bot_speed(self,data):
         # We get the bot_turn_angle in simulation Using same method as Gotogoal.py
@@ -212,6 +217,12 @@ class maze_solver(Node):
         
         self.debugging.setDebugParameters()
 
+        #check if sat_view and bot_view are received
+        if self.have_sat_view and self.have_bot_view:
+            print("Time to move!")
+        else:
+            print("waiting for views from the camera...")
+            return
         # Creating frame to display current robot state to user        
         frame_disp = self.sat_view.copy()
         


### PR DESCRIPTION
Hi! I'm a researcher on bug detection and software robustness focusing on robotic applications. It's our new idea to design a language-irrelevant algorithm, so we are trying to check and fix some python-based programs to prove our algorithm. Since your program is one of the best opensource codes in python for the ROS system, we did a test and found some crashes: 

```
maze_solver:
Traceback (most recent call last):
  ...
  File "/root/ROS2-Path-Planning-and-Maze-Solving/path_planning_ws/install/maze_bot/lib/python3.8/site-packages/maze_bot/maze_solver.py", line 221, in maze_solving
    self.bot_localizer.localize_bot(self.sat_view, frame_disp)
  File "/root/ROS2-Path-Planning-and-Maze-Solving/path_planning_ws/install/maze_bot/lib/python3.8/site-packages/maze_bot/bot_localization.py", line 173, in localize_bot
    self.extract_bg(curr_frame.copy())
  File "/root/ROS2-Path-Planning-and-Maze-Solving/path_planning_ws/install/maze_bot/lib/python3.8/site-packages/maze_bot/bot_localization.py", line 92, in extract_bg
    gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
cv2.error: OpenCV(4.6.0) /io/opencv/modules/imgproc/src/color.simd_helpers.hpp:92: error: (-2:Unspecified error) in function 'cv::impl::{anonymous}::CvtHelper<VScn, VDcn, VDepth, sizePolicy>::CvtHelper(cv::InputArray, cv::OutputArray, int) [with VScn = cv::impl::{anonymous}::Set<3, 4>; VDcn = cv::impl::{anonymous}::Set<1>; VDepth = cv::impl::{anonymous}::Set<0, 2, 5>; cv::impl::{anonymous}::SizePolicy sizePolicy = cv::impl::<unnamed>::NONE; cv::InputArray = const cv::_InputArray&; cv::OutputArray = const cv::_OutputArray&]'
> Invalid number of channels in input image:
>     'VScn::contains(scn)'
> where
>     'scn' is 1
```

```
maze_solver:
Traceback (most recent call last):
  ...
  File "/root/ROS2-Path-Planning-and-Maze-Solving/path_planning_ws/install/maze_bot/lib/python3.8/site-packages/maze_bot/maze_solver.py", line 223, in maze_solving
    self.bot_localizer.localize_bot(self.sat_view, frame_disp)
  File "/root/ROS2-Path-Planning-and-Maze-Solving/path_planning_ws/install/maze_bot/lib/python3.8/site-packages/maze_bot/bot_localization.py", line 173, in localize_bot
    self.extract_bg(curr_frame.copy())
  File "/root/ROS2-Path-Planning-and-Maze-Solving/path_planning_ws/install/maze_bot/lib/python3.8/site-packages/maze_bot/bot_localization.py", line 92, in extract_bg
    gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
cv2.error: OpenCV(4.6.0) /io/opencv/modules/imgproc/src/color.simd_helpers.hpp:94: error: (-2:Unspecified error) in function 'cv::impl::{anonymous}::CvtHelper<VScn, VDcn, VDepth, sizePolicy>::CvtHelper(cv::InputArray, cv::OutputArray, int) [with VScn = cv::impl::{anonymous}::Set<3, 4>; VDcn = cv::impl::{anonymous}::Set<1>; VDepth = cv::impl::{anonymous}::Set<0, 2, 5>; cv::impl::{anonymous}::SizePolicy sizePolicy = cv::impl::<unnamed>::NONE; cv::InputArray = const cv::_InputArray&; cv::OutputArray = const cv::_OutputArray&]'
> Unsupported depth of input image:
>     'VDepth::contains(depth)'
> where
>     'depth' is 6 (CV_64F)
```

```
maze_solver:
Traceback (most recent call last):
  File "/root/ROS2-Path-Planning-and-Maze-Solving/path_planning_ws/install/maze_bot/lib/maze_bot/maze_solver", line 11, in <module>
    load_entry_point('maze-bot==0.0.0', 'console_scripts', 'maze_solver')()
  File "/root/ROS2-Path-Planning-and-Maze-Solving/path_planning_ws/install/maze_bot/lib/python3.8/site-packages/maze_bot/maze_solver.py", line 272, in main
    rclpy.spin(node_obj)
  File "/opt/ros/foxy/lib/python3.8/site-packages/rclpy/__init__.py", line 191, in spin
    executor.spin_once()
  File "/opt/ros/foxy/lib/python3.8/site-packages/rclpy/executors.py", line 714, in spin_once
    raise handler.exception()
  File "/opt/ros/foxy/lib/python3.8/site-packages/rclpy/task.py", line 239, in __call__
    self._handler.send(None)
  File "/opt/ros/foxy/lib/python3.8/site-packages/rclpy/executors.py", line 429, in handler
    await call_coroutine(entity, arg)
  File "/opt/ros/foxy/lib/python3.8/site-packages/rclpy/executors.py", line 343, in _execute_timer
    await await_or_execute(tmr.callback)
  File "/opt/ros/foxy/lib/python3.8/site-packages/rclpy/executors.py", line 118, in await_or_execute
    return callback(*args)
  File "/root/ROS2-Path-Planning-and-Maze-Solving/path_planning_ws/install/maze_bot/lib/python3.8/site-packages/maze_bot/maze_solver.py", line 245, in maze_solving
    bot_view = cv2.resize(self.bot_view, (int(frame_disp.shape[0]/2),int(frame_disp.shape[1]/2)))
AttributeError: 'maze_solver' object has no attribute 'bot_view'
```

Analysis:
There is a chance some of the messages such as `/BotCamera/image_raw` may have a delay in the real situation, also even in the simulation of gazebo, which is the reason of the crashes occurred when we tested. 

Solution:
Therefore, I just change the logic of maze_solving: check first if a real bot_view and sat_view are received , then continue to do the rest things. 

Hoping you can agree this merge.
