### PR TITLE
avoid bad image message

### DIFF
--- a/path_planning_ws/src/maze_bot/maze_bot/maze_solver.py
+++ b/path_planning_ws/src/maze_bot/maze_bot/maze_solver.py
@@ -77,12 +77,19 @@ class maze_solver(Node):
         self.debugging = Debugging()
 
     def get_video_feed_cb(self,data):
-        frame = self.bridge.imgmsg_to_cv2(data,'bgr8')
+        try:
+            frame = self.bridge.imgmsg_to_cv2(data,'bgr8')
+        except CvBridgeError as e:
+            print(e)
+            return
         self.sat_view = frame
     
     def process_data_bot(self, data):
-      self.bot_view = self.bridge.imgmsg_to_cv2(data,'bgr8') # performing conversion
-
+        try:
+            self.bot_view = self.bridge.imgmsg_to_cv2(data,'bgr8') # performing conversion
+        except CvBridgeError as e:
+            print(e)
+            return
     def get_bot_speed(self,data):
         # We get the bot_turn_angle in simulation Using same method as Gotogoal.py
         self.bot_speed = -(data.twist.twist.linear.x)


### PR DESCRIPTION
In addition, considering the error when transferring the information and other noise, we mutate some of the image message and there will be a  crash like following:

```
maze_solver:
Traceback (most recent call last):
  File "/opt/ros/foxy/lib/python3.8/site-packages/cv_bridge/core.py", line 191, in imgmsg_to_cv2
    res = cvtColor2(im, img_msg.encoding, desired_encoding)
RuntimeError: OpenCV(4.2.0) ../modules/imgproc/src/color.cpp:182: error: (-215:Assertion failed) !_src.empty() in function 'cvtColor'
```
It's because of a mutation of the message's width and height data, causing the cvtColor2 memset a zero-size src to transfer.
Maybe it's hard to happen in a stable simulation environment, we hope it can be addressed as a robust feature.